### PR TITLE
The later releases of SOLR 7 don't have sha1 hashes.  Also bump defau…

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,7 +1,7 @@
 ---
 
 # Solr version to download an install
-solr::version: '7.1.0'
+solr::version: '7.7.0'
 
 # Sets the user for file ownership. Valid options: any valid user. Default: `solr`
 solr::user: 'solr'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,8 +69,8 @@ class solr (
   # Download the installer archive and extract the install script
   $install_archive = "${install_dir}/solr-${$version}.tgz"
   archive { $install_archive:
-    checksum_type => 'sha1',
-    checksum_url  => "http://archive.apache.org/dist/lucene/solr/${$version}/solr-${$version}.tgz.sha1",
+    checksum_type => 'sha512',
+    checksum_url  => "http://archive.apache.org/dist/lucene/solr/${$version}/solr-${$version}.tgz.sha512",
     cleanup       => false,
     creates       => 'dummy_value', # extract every time. This is needed because archive has unexpected behaviour without it. (seems to be mandatory, instead of optional)
     extract       => true,


### PR DESCRIPTION
The later releases of SOLR 7 don't have sha1 hashes provided at http://archive.apache.org/dist/lucene/solr/.  Instead switch to sha512 which is available.