### PR TITLE
Older versions of solr need their checksum for download defined.

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,6 +3,9 @@
 # Solr version to download an install
 solr::version: '7.7.0'
 
+# Checksum type to download
+solr::checksum_type: 'sha512'
+
 # Sets the user for file ownership. Valid options: any valid user. Default: `solr`
 solr::user: 'solr'
 # Sets whether or not this instance will manage the defined user. Valid options: `true` or `false`. Default: `true`.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,7 @@ class solr (
   String  $install_dir,
   String  $service_name,
   String  $version,
+  String  $checksum_type,
   Integer $port,
   String  $memory,
   String  $data_dir,
@@ -69,8 +70,8 @@ class solr (
   # Download the installer archive and extract the install script
   $install_archive = "${install_dir}/solr-${$version}.tgz"
   archive { $install_archive:
-    checksum_type => 'sha512',
-    checksum_url  => "http://archive.apache.org/dist/lucene/solr/${$version}/solr-${$version}.tgz.sha512",
+    checksum_type => $checksum_type,
+    checksum_url  => "http://archive.apache.org/dist/lucene/solr/${$version}/solr-${$version}.tgz.${checksum_type}",
     cleanup       => false,
     creates       => 'dummy_value', # extract every time. This is needed because archive has unexpected behaviour without it. (seems to be mandatory, instead of optional)
     extract       => true,


### PR DESCRIPTION
Defaults to the newer sha512 checksum files Apache offer.