### PR TITLE
Fix issue #4 : error if zooKeeper not used.

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -39,4 +39,3 @@ solr::port: 8983
 # e.g. 
 # solr::zk_hosts: 
 #   - 'localhost:2181'
-solr::zk_hosts: []

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -39,3 +39,4 @@ solr::port: 8983
 # e.g. 
 # solr::zk_hosts: 
 #   - 'localhost:2181'
+solr::zk_hosts: 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,7 +40,7 @@ class solr (
   String  $memory,
   Boolean $jmx_remote,
   String  $data_dir,
-  Array[String] $zk_hosts,
+  Optional[Array[String]] $zk_hosts,
 ) {
 
   #------------------------------------------------------------------------------#


### PR DESCRIPTION
Zookeeper host is now optional to be left undef when not used.
Default value is not defined accordingly.